### PR TITLE
Add XML docs and ASP.NET Core end-to-end tests

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,8 +22,12 @@ jobs:
         run: dotnet restore --configfile NuGet.config
       - name: Build
         run: dotnet build --no-restore
-      - name: Test
-        run: dotnet test --no-build --verbosity normal
+      - name: Test JSON
+        run: dotnet test BoBo.JSON.Tests/BoBo.JSON.Tests.csproj --no-build --verbosity normal
+      - name: Test XML
+        run: dotnet test BoBo.XML.Tests/BoBo.XML.Tests.csproj --no-build --verbosity normal
+      - name: Test ASP.NET Core end-to-end
+        run: dotnet test BoBo.ASPNETCore.Tests/BoBo.ASPNETCore.Tests.csproj --no-build --verbosity normal
 
   publish:
     needs: build

--- a/BoBo.ASPNETCore.TestEndpoints/Controllers/SampleController.cs
+++ b/BoBo.ASPNETCore.TestEndpoints/Controllers/SampleController.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Collections.Generic;
 
@@ -8,6 +8,11 @@ namespace BoBo.ASPNETCore.TestEndpoints.Controllers;
 [Route("[controller]")]
 public class SampleController : ControllerBase
 {
+    /// <summary>
+    /// Endpoint used exclusively for testing the middleware.
+    /// It always throws an exception.
+    /// </summary>
+    /// <returns>This method never returns; it always throws an exception.</returns>
     [HttpGet]
     public IEnumerable<object> Get()
     {

--- a/BoBo.ASPNETCore.TestEndpoints/Program.cs
+++ b/BoBo.ASPNETCore.TestEndpoints/Program.cs
@@ -32,7 +32,7 @@ app.UseAuthorization();
 
 app.MapControllers();
 
-app.UseMiddleware(typeof(Catch),    
+app.UseMiddleware(typeof(Catch),
     System.Net.HttpStatusCode.InternalServerError,
     new WithContentType("text/xml"),
     new XmlDigest(
@@ -43,3 +43,8 @@ app.UseMiddleware(typeof(Catch),
 );
 
 app.Run();
+
+/// <summary>
+/// Exposes the entry point class for integration tests.
+/// </summary>
+public partial class Program { }

--- a/BoBo.ASPNETCore.Tests/BoBo.ASPNETCore.Tests.csproj
+++ b/BoBo.ASPNETCore.Tests/BoBo.ASPNETCore.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BoBo.ASPNETCore.TestEndpoints\BoBo.ASPNETCore.TestEndpoints.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/BoBo.ASPNETCore.Tests/CatchMiddlewareE2ETest.cs
+++ b/BoBo.ASPNETCore.Tests/CatchMiddlewareE2ETest.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using System.Xml;
+using BoBo.ASPNETCore.TestEndpoints;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace BoBo.ASPNETCore.Tests;
+
+public class CatchMiddlewareE2ETest
+{
+    [Fact]
+    public async Task Middleware_Should_Return_Formatted_Exception()
+    {
+        using var factory = new WebApplicationFactory<Program>();
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("https://localhost")
+        });
+
+        var response = await client.GetAsync("/Sample");
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        Assert.Equal("text/xml", response.Content.Headers.ContentType?.MediaType);
+
+        var content = await response.Content.ReadAsStringAsync();
+        var document = new XmlDocument();
+        document.LoadXml(content);
+        Assert.Equal("wow", document.SelectSingleNode("/Exception/Message")?.InnerText);
+        Assert.Contains("such fun", document.SelectSingleNode("/Exception/InnerException/Message")?.InnerText);
+    }
+}

--- a/BoBo.ASPNETCore/Headers/CombinedHeaders.cs
+++ b/BoBo.ASPNETCore/Headers/CombinedHeaders.cs
@@ -1,21 +1,36 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace BoBo.ASPNETCore.Middleware;
 
+/// <summary>
+/// Combines multiple <see cref="IHeaders"/> instances into a single collection.
+/// </summary>
 public class CombinedHeaders : IHeaders
 {
     private readonly List<IHeaders> hooks;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CombinedHeaders"/> class.
+    /// </summary>
+    /// <param name="hooks">Headers providers to combine.</param>
     public CombinedHeaders(params IHeaders[] hooks) : this(new List<IHeaders>(hooks))
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CombinedHeaders"/> class.
+    /// </summary>
+    /// <param name="hooks">Headers providers to combine.</param>
     public CombinedHeaders(List<IHeaders> hooks)
     {
         this.hooks = hooks;
     }
 
+    /// <summary>
+    /// Builds a combined list of headers from all wrapped providers.
+    /// </summary>
+    /// <returns>The aggregated list of headers.</returns>
     public List<KeyValuePair<string, string>> Make()
     {
         return hooks

--- a/BoBo.ASPNETCore/Headers/IHeaders.cs
+++ b/BoBo.ASPNETCore/Headers/IHeaders.cs
@@ -1,8 +1,15 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace BoBo.ASPNETCore.Middleware;
 
+/// <summary>
+/// Represents a factory for HTTP headers that will be added to the response.
+/// </summary>
 public interface IHeaders
 {
+    /// <summary>
+    /// Builds the collection of headers.
+    /// </summary>
+    /// <returns>A list of header name and value pairs.</returns>
     List<KeyValuePair<string, string>> Make();
 }

--- a/BoBo.ASPNETCore/Headers/WithContentType.cs
+++ b/BoBo.ASPNETCore/Headers/WithContentType.cs
@@ -1,16 +1,27 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace BoBo.ASPNETCore.Middleware;
 
+/// <summary>
+/// Produces a <c>Content-Type</c> header with a specified value.
+/// </summary>
 public class WithContentType : IHeaders
 {
     private readonly string type;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WithContentType"/> class.
+    /// </summary>
+    /// <param name="type">Value of the <c>Content-Type</c> header.</param>
     public WithContentType(string type)
     {
         this.type = type;
     }
 
+    /// <summary>
+    /// Creates the header collection containing the <c>Content-Type</c> entry.
+    /// </summary>
+    /// <returns>A list with a single header pair.</returns>
     public List<KeyValuePair<string, string>> Make()
     {
         return new List<KeyValuePair<string, string>>()

--- a/BoBo.sln
+++ b/BoBo.sln
@@ -17,6 +17,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BoBo.XML", "BoBo.XML\BoBo.X
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BoBo.XML.Tests", "BoBo.XML.Tests\BoBo.XML.Tests.csproj", "{87E2CFD3-C78D-4C5D-96BB-9D3FE1A26CE0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BoBo.ASPNETCore.Tests", "BoBo.ASPNETCore.Tests\BoBo.ASPNETCore.Tests.csproj", "{0102F132-5606-46E4-B009-5006351D7254}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +53,10 @@ Global
 		{87E2CFD3-C78D-4C5D-96BB-9D3FE1A26CE0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{87E2CFD3-C78D-4C5D-96BB-9D3FE1A26CE0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{87E2CFD3-C78D-4C5D-96BB-9D3FE1A26CE0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0102F132-5606-46E4-B009-5006351D7254}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0102F132-5606-46E4-B009-5006351D7254}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0102F132-5606-46E4-B009-5006351D7254}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0102F132-5606-46E4-B009-5006351D7254}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- document ASP.NET Core headers and Catch middleware for clarity
- expose test endpoint Program and document SampleController
- add ASP.NET Core end-to-end test verifying middleware output
- run JSON, XML, and ASP.NET Core end-to-end tests in GitHub Actions

## Testing
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68910573ce10832e8b3c8a071ce4a497